### PR TITLE
Show cards in two rows using Grid

### DIFF
--- a/src/components/Card.css
+++ b/src/components/Card.css
@@ -3,12 +3,12 @@
     text-align: center;
     margin: 0.05ch;
     font-family: monospace;
-    font-size: 125%;
+    font-size: 250%;
     font-weight: bold;
     border-style: solid;
     border-width: 0.1px;
     color: white;
-    width: 0.26in;
+    width: 0.48in;
     padding: 0 0 0 0;
 }
 

--- a/src/components/Game.css
+++ b/src/components/Game.css
@@ -15,12 +15,6 @@
     font-weight: bold;
 }
 
-.hand {
-    text-align: center;
-    display: inline-block;
-    margin: 5px 5px 5px 5px
-}
-
 .final-score {
     font-weight: bold;
     font-size: 150%;
@@ -32,6 +26,33 @@
 
 .final-score-loss {
     color: red;
+}
+
+.game-cards {
+    display: grid;
+    grid-gap: 1px 1px;
+    /* grid-template-columns: 6; */
+    grid-template-rows: 45%;
+}
+
+.hand {
+    /* text-align: center; */
+    /* display: inline-block; */
+    grid-column: 1 / span 4;
+    /* margin: 5px 5px 5px 5px; */
+    margin: auto;
+}
+
+.draw-discard-card {
+    grid-column: 5 / span 1;
+    /* margin: 5px 5px 5px 5px; */
+    margin: auto;
+}
+
+.last-drawn-card {
+    grid-column: 6 / span 1;
+    /* margin: 5px 5px 5px 5px; */
+    margin: auto;
 }
 
 .draw {

--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -20,9 +20,12 @@ class Game extends Component {
   }
 
   render() {
-    let html_hand = this.props.hand.map(card =>
-      this.createCard(card, true, false)
-    );
+    let hand_r1 = this.props.hand.slice(0, 4);
+    let hand_r2 = this.props.hand.slice(4, this.props.hand.length);
+
+    let cards_r1 = hand_r1.map(c => this.createCard(c, true, false));
+    let cards_r2 = hand_r2.map(c => this.createCard(c, true, false));
+
     let discard = " ";
     if (this.props.top_of_discard) {
       discard = this.createCard(this.props.top_of_discard, false, false);
@@ -40,15 +43,16 @@ class Game extends Component {
           {this.props.deck_length}
           {"/52"})<span className="points">{this.props.points} pts</span>{" "}
         </div>
-        <div>
-          <span className="hand"> {html_hand} </span> {" | "}{" "}
-          {this.createCard("?x", false)}
-          {discard}
-          <span>
-            {this.props.last_draw ? " | " : ""}
-            {last_draw}
-          </span>
-        </div>{" "}
+        <div className="game-cards">
+          <div className="hand"> {cards_r1} </div>
+          <div className="draw-discard-card">
+            {this.createCard("?x", false)}
+          </div>
+          <div className="last-drawn-card"> </div>
+          <div className="hand"> {cards_r2} </div>
+          <div className="draw-discard-card">{discard}</div>
+          <div className="last-drawn-card">{last_draw}</div>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
The grid use is a little wonky but a huge improvement, for mobile ... probably

Before:
<img width="412" alt="one-line" src="https://user-images.githubusercontent.com/1449882/57108449-62653580-6cf8-11e9-9442-7682535efc7a.png">

After:
<img width="328" alt="two-lines" src="https://user-images.githubusercontent.com/1449882/57108458-65f8bc80-6cf8-11e9-8f4f-6d8417bbe4df.png">